### PR TITLE
Move issue templates to .github folder

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-bug_report.md
@@ -1,6 +1,8 @@
 ---
-title: 'Bug Report'
+name: 'Bug Report'
+about: Create a report to help us improve
 labels: bug
+
 ---
 
 ### Have you identified a reproducible problem in this project? 

--- a/.github/ISSUE_TEMPLATE/2-feature_request.md
+++ b/.github/ISSUE_TEMPLATE/2-feature_request.md
@@ -1,5 +1,6 @@
 ---
-title: 'Feature Request'
+name: 'Feature Request'
+about: Suggest an idea for this project
 labels: feature
 ---
 


### PR DESCRIPTION
Trying to get the issue templates to appear when you click on 'New Issue'. Basing this off of Node.js repo to hopefully mimic the behavior. The GitHub docs on this are severely lacking.