### PR TITLE
Hotfix: Remove unneeded properties path

### DIFF
--- a/infrastructure/azuredeploy.json
+++ b/infrastructure/azuredeploy.json
@@ -101,7 +101,7 @@
             "displayName": "appSettings"
           },
           "properties": {
-            "APPLICATION_INSIGHTS_IKEY": "[reference(concat(resourceId('Microsoft.Insights/components', variables('components_insights_name')))).Properties.InstrumentationKey]",
+            "APPLICATION_INSIGHTS_IKEY": "[reference(concat(resourceId('Microsoft.Insights/components', variables('components_insights_name')))).InstrumentationKey]",
             "DB_CONNSTR": "[parameters('database_connection_string')]",
             "DB_NAME": "IMDb",
             "RESOURCE_GROUP": "[resourceGroup().name]",
@@ -139,7 +139,7 @@
             "displayName": "appSettings"
           },
           "properties": {
-            "APPLICATION_INSIGHTS_IKEY": "[reference(concat(resourceId('Microsoft.Insights/components', variables('components_insights_name')))).Properties.InstrumentationKey]",
+            "APPLICATION_INSIGHTS_IKEY": "[reference(concat(resourceId('Microsoft.Insights/components', variables('components_insights_name')))).InstrumentationKey]",
             "TEST": "foo",
             "DB_CONNSTR": "[parameters('database_connection_string')]",
             "DB_NAME": "IMDb",


### PR DESCRIPTION
We have an unnecessary property path in our arm templates - validation doesn't catch this unfortunately, but deployment showed us what was going on. As such, fixing 😸 