### PR TITLE
Add websites_port app setting for ui

### DIFF
--- a/infrastructure/azuredeploy.json
+++ b/infrastructure/azuredeploy.json
@@ -180,7 +180,8 @@
             "RESOURCE_GROUP": "[resourceGroup().name]",
             "DOCKER_REGISTRY_SERVER_USERNAME": "[parameters('docker_registry_username')]",
             "DOCKER_REGISTRY_SERVER_PASSWORD": "[parameters('docker_registry_password')]",
-            "DOCKER_REGISTRY_SERVER_URL": "[parameters('docker_registry_url')]"
+            "DOCKER_REGISTRY_SERVER_URL": "[parameters('docker_registry_url')]",
+            "WEBSITES_PORT": "8080"
           }
         }
       ]


### PR DESCRIPTION
For the ui containers, they need to start with port of 8080, so this configuration change will deploy the app services with the app setting for all the ui pieces to have this added by default.