### PR TITLE
Health endpoint

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -59,6 +59,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>com.microsoft.azure</groupId>
 			<artifactId>applicationinsights-web</artifactId>
 			<version>2.2.1</version>


### PR DESCRIPTION
This PR adds a dependency on [spring boot actuator](https://github.com/spring-projects/spring-boot/tree/master/spring-boot-project/spring-boot-actuator) which adds an endpoint `/actuator/health` which will give a status of the application and in the body will have a status message. This endpoint is unauthorized.

ie
```
$ curl localhost:8080/actuator/health
{"status":"UP"}
```

This will also enable an endpoint `/actuator/info` that will right now return an empty object, but can be configured to have content like build information, etc. This can also be disabled with an environment variable if we choose to do so. 

