### PR TITLE
Custom health endpoint

### DIFF
--- a/api/src/main/java/com/microsoft/cse/reference/spring/dal/controllers/HealthEndpointController.java
+++ b/api/src/main/java/com/microsoft/cse/reference/spring/dal/controllers/HealthEndpointController.java
@@ -1,0 +1,15 @@
+package com.microsoft.cse.reference.spring.dal.controllers;
+
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Create a custom endpoint that returns status OK when Java App is running
+ */
+@RestController
+public class HealthEndpointController {
+
+    @RequestMapping(method = RequestMethod.GET, value = "/health")
+    public String getStatus() {
+        return new String("Alive");
+    }
+}

--- a/api/src/test/java/com/microsoft/cse/reference/spring/dal/integration/BasicRouteTests.java
+++ b/api/src/test/java/com/microsoft/cse/reference/spring/dal/integration/BasicRouteTests.java
@@ -358,6 +358,18 @@ public class BasicRouteTests {
         Assert.assertEquals(resPeople.getHeaders().getAccessControlAllowOrigin(), "*");
     }
 
+
+    @Test
+    public void ValidateHealthEndpoint() throws URISyntaxException {
+        ResponseEntity<String> resHealth = this.rest.exchange(RequestEntity
+                        .get(new URI("http://localhost:" + httpPort + "/health"))
+                        .build(),
+                String.class
+        );
+
+        Assert.assertTrue(resHealth.getStatusCode().is2xxSuccessful());
+    }
+
     /**
      * A configuration instance for these tests
      */


### PR DESCRIPTION
Adds an endpoint for checking if the service is live ie the java app is running at `/health` which will return a 200 status. This is a workaround until [this issue](https://github.com/Microsoft/containers-rest-cosmos-appservice-java/issues/46) is resolved.