### PR TITLE
Fix global acr to have a suitable default name

### DIFF
--- a/infrastructure/global-resources/azuredeploy.json
+++ b/infrastructure/global-resources/azuredeploy.json
@@ -12,7 +12,7 @@
         },
         "container_registry_name": {
             "type": "string",
-            "defaultValue": "acr-images"
+            "defaultValue": "acrImages"
         },
         "traffic_manager_profiles_name": {
             "type": "string",


### PR DESCRIPTION
Fix the global acr instance deployment arm to contain a valid container instance name.