### PR TITLE
Fix arm for cosmos database to use unique name

### DIFF
--- a/infrastructure/global-resources/azuredeploy.json
+++ b/infrastructure/global-resources/azuredeploy.json
@@ -25,7 +25,7 @@
             "kind": "MongoDB",
             "name": "[parameters('database_account_name')]",
             "apiVersion": "2015-04-08",
-            "location": "westus",
+            "location": "[resourceGroup().location]",
             "tags": {
                 "defaultExperience": "MongoDB"
             },


### PR DESCRIPTION
The Azure platform requires that cosmos instances are unique - our default values should respect that. I also included a change here to name our database inside cosmos simply "data" as i had some concerns about the hyphen, and figured i'd be safe rather than sorry.