### PR TITLE
Removed "Jackson" from the page

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,5 +1,5 @@
 
-# Project Jackson Infrastructure
+# Project Infrastructure
 
 This repository includes the ARM templates for Project Jackson.
 


### PR DESCRIPTION
Just cleaning up the "Project Jackson" indicator. 

Changed it to "Project"