### PR TITLE
Removed alpine docker image to fix dev env runtime issue.

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -17,7 +17,7 @@ WORKDIR /tmp/
 RUN mvn test package
 
 # Start with a base image containing Java runtime
-FROM openjdk:8-jdk-alpine
+FROM openjdk:8-jdk
 
 # Add a volume pointing to /tmp
 VOLUME /tmp


### PR DESCRIPTION
Removed docker alpine from the docker build FROM.  Alpine version of the open-jdk image fails to launch the embedded mongodb when running as a development environment.