### PR TITLE
Hotfix: `load_env.sh` default db in interactive walkthrough

### DIFF
--- a/data/load_env.sh
+++ b/data/load_env.sh
@@ -142,7 +142,7 @@ readLocation() {
 }
 
 readDbName () {
-	dbNames="$(az cosmosdb list -g $resourceGroupName -o tsv | cut -f12)"
+	dbNames="$(az cosmosdb list -g $resourceGroupName -o tsv | cut -f13)"
 	defaultDb=(${dbNames[@]})
 	
 	while ([[ -z "$dbName" ]]); do


### PR DESCRIPTION
When showing the user the default cosmosdb resource, the  line that grabs a column from the `az cosmosdb list` command needed updating.